### PR TITLE
Fixed Minor Bug in Technology Bubbles

### DIFF
--- a/resources/styles/styles.css
+++ b/resources/styles/styles.css
@@ -2220,6 +2220,18 @@ footer > a:hover {
         gap: 0.25rem 1.75rem;
     }
 
+    .technology-bubble:nth-child(n)::before {
+        font-size: 1.3rem;
+    }
+
+    .technology-bubble:nth-child(n):hover::before {
+        transform: translate(-50%, 250%);
+    }
+
+    .technology-bubble:nth-child(5):hover::before {
+        transform:  translate(-50%, 125%);
+    }
+
     footer {
         height: 100vh;
         display: flex;


### PR DESCRIPTION
# Description:

Fixed a minor bug where the text on one of the technology bubbles was cut off by the width of the screen.

## Changes:

- Reduced the size of the text in the technology bubbles on small (older) screen sizes.
- Increased the percentage that the text travels when hovered to match its new size.
- Tweaked bubble number 5, which is always slightly bigger than the rest, to ensure it works properly with this new change.